### PR TITLE
Update to latest version of http-signature

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	},
 	"main": "lib/index.js",
 	"dependencies": {
-		"http-signature": "0.9.x"
+		"http-signature": "0.11.x"
 	},
 	"devDependencies": {
 		"mocha": ">=0.3.6",


### PR DESCRIPTION
Attempting to validate signatures from clients with the latest
http-signature was resulting in errors:
 `InvalidHeaderError: signature was empty`
Due to changes in http-signature. Changing the dependency to the latest
0.11.x http-signature fixes this issue.
